### PR TITLE
move nowAppZone extension here. Allow to set a default application ti…

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,13 +7,13 @@ executors:
     environment:
       GRADLE_OPTS: "-Dorg.gradle.caching=true -Dorg.gradle.daemon=false -Dorg.gradle.workers.max=4 -Dorg.gradle.console=plain"
     docker:
-      - image: yakworks/builder:jdk11
+      - image: yakworks/bullseye:jdk11
   builder-medium: # 2cpus 4gb ram
     resource_class: 'medium'
     environment:
       GRADLE_OPTS: "-Dorg.gradle.caching=true -Dorg.gradle.daemon=false -Dorg.gradle.workers.max=2 -Dorg.gradle.console=plain"
     docker:
-      - image: yakworks/builder:jdk11
+      - image: yakworks/bullseye:jdk11
 
 commands:
   restore_gradle_cache:
@@ -78,7 +78,7 @@ jobs:
       - save_build_cache
 
   ship-it:
-    executor: builder-large
+    executor: builder-medium
     steps:
       - checkout
       - restore_gradle_cache

--- a/groovy-commons/src/main/groovy/yakworks/commons/extensions/AppTimeZone.groovy
+++ b/groovy-commons/src/main/groovy/yakworks/commons/extensions/AppTimeZone.groovy
@@ -1,0 +1,61 @@
+/*
+* Copyright 2023 original authors
+* SPDX-License-Identifier: Apache-2.0
+*/
+package yakworks.commons.extensions
+
+import java.time.LocalDate
+import java.time.LocalDateTime
+import java.time.ZoneId
+
+import groovy.transform.CompileStatic
+
+/**
+ * Holder for the App default time-zone.
+ * The system zone will normally be set to UTC.
+ * The App can have a different default time zone for where most of the users are
+ * or the timezone accounting is based on. A GL posting date for example is usually anchored to a timezone for balancing purposes.
+ *
+ * So for example when I want an invoice or GL date for today and its 9:00pm Eastern time (new york)
+ * then its tomorrow at 1am in UTC so using the vanilla java LocalDate.now() will give a date for tomorrow when the accounting books
+ * are still open and running for today.
+ */
+@SuppressWarnings(['PropertyName'])
+@CompileStatic
+class AppTimeZone {
+
+    /** The default timezone for App Time, for spring gets set after  */
+    static TimeZone APP_ZONE = TimeZone.getTimeZone("America/New_York")
+
+    static void setTimeZone(TimeZone zone){
+        APP_ZONE = zone
+    }
+
+    static TimeZone getTimeZone(){
+        APP_ZONE
+    }
+
+    static ZoneId getZoneId(){
+        APP_ZONE.toZoneId()
+    }
+
+    /**
+     * Uses the app default zone to get the current date.
+     * The system zone should be set to UTC. The App can have a default time zone.
+     *
+     * So for example when I want today and its 9:00pm Eastern, its tomorrow at 1am in UTC so using the default
+     * LocalDate.now() give a date for tomorrow.
+     *
+     * @return the LocalDate in the default time zone.
+     */
+    static LocalDate localDateNow() {
+        assert APP_ZONE
+        LocalDate.now(getZoneId())
+    }
+
+    static LocalDateTime localDateTimeNow() {
+        assert APP_ZONE
+        LocalDateTime.now(getZoneId())
+    }
+
+}

--- a/groovy-commons/src/main/groovy/yakworks/commons/extensions/LocalDateTimeStaticExt.groovy
+++ b/groovy-commons/src/main/groovy/yakworks/commons/extensions/LocalDateTimeStaticExt.groovy
@@ -1,0 +1,48 @@
+/*
+* Copyright 2023 original authors
+* SPDX-License-Identifier: Apache-2.0
+*/
+package yakworks.commons.extensions
+
+import java.time.LocalDate
+import java.time.LocalDateTime
+import java.time.ZoneId
+
+import groovy.transform.CompileStatic
+
+@CompileStatic
+class LocalDateTimeStaticExt {
+
+    /**
+     * Uses the app default zone to get the current date.
+     * The system zone should be set to UTC. The App can have a default time zone.
+     *
+     * So for example when I want today and its 9:00pm Eastern, its tomorrow at 1am in UTC so using the default
+     * LocalDate.now() give a date for tomorrow.
+     *
+     * @return the LocalDate in the default time zone.
+     */
+    static LocalDate nowAppZone(final LocalDate type) {
+        LocalDate.now(AppTimeZone.zoneId)
+    }
+
+    static LocalDateTime nowAppZone(final LocalDateTime type) {
+        LocalDateTime.now(AppTimeZone.zoneId)
+    }
+
+
+    /**
+     * Sister to ZoneId.systemDefault()
+     * Gets the App default time-zone.
+     * The system zone will normally be set to UTC.
+     * The App can have a different default time zone for where most of the users are.
+     *
+     * So for example when I want today and its 9:00pm Eastern, its tomorrow at 1am in UTC so using the default
+     * LocalDate.now() give a date for tomorrow.
+     *
+     * @return the LocalDate in the default time zone.
+     */
+    static ZoneId appDefault(final ZoneId type) {
+        return AppTimeZone.zoneId
+    }
+}

--- a/groovy-commons/src/main/groovy/yakworks/commons/extensions/ZonedTimeStaticExt.groovy
+++ b/groovy-commons/src/main/groovy/yakworks/commons/extensions/ZonedTimeStaticExt.groovy
@@ -1,0 +1,27 @@
+/*
+* Copyright 2023 original authors
+* SPDX-License-Identifier: Apache-2.0
+*/
+package yakworks.commons.extensions
+
+import java.time.ZonedDateTime
+
+import groovy.transform.CompileStatic
+
+@CompileStatic
+class ZonedTimeStaticExt {
+
+    /**
+     * Uses the app default zone to get the current date.
+     * The system zone should be set to UTC. The App can have a default time zone.
+     *
+     * So for example when I want today and its 9:00pm Eastern, its tomorrow at 1am in UTC so using the default
+     * ZonedDateTime.now() give a date for tomorrow. This will give now for today in the Eastern time zone.
+     *
+     * @return the LocalDate in the default time zone.
+     */
+    static ZonedDateTime nowAppZone(final ZonedDateTime type) {
+        ZonedDateTime.now(AppTimeZone.zoneId)
+    }
+
+}

--- a/groovy-commons/src/main/groovy/yakworks/commons/lang/ZonedDateUtil.groovy
+++ b/groovy-commons/src/main/groovy/yakworks/commons/lang/ZonedDateUtil.groovy
@@ -1,0 +1,55 @@
+/*
+* Copyright 2024 original authors
+* SPDX-License-Identifier: Apache-2.0
+*/
+package yakworks.commons.lang
+
+import java.time.LocalDateTime
+import java.time.ZoneId
+import java.time.ZonedDateTime
+import java.time.temporal.ChronoUnit
+import java.time.temporal.Temporal
+
+import groovy.transform.CompileStatic
+
+@CompileStatic
+class ZonedDateUtil {
+
+    static LocalDateTime toLocalDateTimeZone(ZonedDateTime zonedDateTime, ZoneId toZoneId){
+        return zonedDateTime
+            .withZoneSameInstant(toZoneId)
+            .toLocalDateTime()
+    }
+
+    static ZonedDateTime toZonedDateTime(ZonedDateTime zonedDateTime, ZoneId toZoneId){
+        return zonedDateTime.withZoneSameInstant(toZoneId)
+    }
+
+    static LocalDateTime toLocalDateTimeZone(LocalDateTime localDateTime, ZoneId fromZoneId, ZoneId toZoneId){
+        return localDateTime.atZone(fromZoneId)
+            .withZoneSameInstant(toZoneId)
+            .toLocalDateTime()
+    }
+
+    //returns hours offset from UTC
+    static int hoursOffset(ZoneId zoneId){
+        var offset = zoneId.getOffset()
+        BigDecimal hrs = offset.totalSeconds / 60 / 60
+        return hrs.toInteger()
+    }
+
+    //for testing, returns hours between 2 times.
+    static long hoursBetween(LocalDateTime ldtInclusive, LocalDateTime ldtExclusive) {
+        return ChronoUnit.HOURS.between(ldtInclusive, ldtExclusive)
+    }
+
+    /** used for testing to see if 2 times are within 60 seconds of each other */
+    static boolean isSameMinute(Temporal t1, Temporal t2){
+        ChronoUnit.SECONDS.between(t1, t2).abs() < 60
+    }
+
+    /** used for testing to see if 2 times are within 60 seconds of each other */
+    static boolean isSameSecond(Temporal t1, Temporal t2){
+        ChronoUnit.SECONDS.between(t1, t2).abs() < 1
+    }
+}

--- a/groovy-commons/src/main/resources/META-INF/services/org.codehaus.groovy.runtime.ExtensionModule
+++ b/groovy-commons/src/main/resources/META-INF/services/org.codehaus.groovy.runtime.ExtensionModule
@@ -2,4 +2,5 @@ moduleName = groovy-commons-extensions
 moduleVersion = ${moduleVersion}
 extensionClasses = yakworks.commons.extensions.PathExtensions,\
                    yakworks.commons.extensions.MapExtensions
-# staticExtensionClasses = yakworks.commons.extensions.MathStaticExtensions
+staticExtensionClasses = yakworks.commons.extensions.LocalDateTimeStaticExt,\
+                            yakworks.commons.extensions.ZonedTimeStaticExt

--- a/groovy-commons/src/test/groovy/yakworks/commons/extensions/AppTimeZoneSpec.groovy
+++ b/groovy-commons/src/test/groovy/yakworks/commons/extensions/AppTimeZoneSpec.groovy
@@ -1,0 +1,58 @@
+/*
+* Copyright 2019 Yak.Works - Licensed under the Apache License, Version 2.0 (the "License")
+* You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+*/
+package yakworks.commons.extensions
+
+
+import java.time.LocalDate
+import java.time.LocalDateTime
+import java.time.ZoneId
+import java.time.ZonedDateTime
+import java.time.temporal.ChronoUnit
+
+import spock.lang.Specification
+import yakworks.commons.lang.ZonedDateUtil
+
+class AppTimeZoneSpec extends Specification {
+
+    void "test now"() {
+        when:
+        TimeZone.setDefault(TimeZone.getTimeZone("UTC"));
+        var etz = TimeZone.getTimeZone("America/New_York")
+        AppTimeZone.setTimeZone(etz)
+
+        var ldNow = LocalDateTime.now().truncatedTo(ChronoUnit.MINUTES)
+        var ldEt = AppTimeZone.localDateTimeNow().truncatedTo(ChronoUnit.MINUTES)
+        int hrsOffset = ZonedDateUtil.hoursOffset(etz.toZoneId())
+
+        then:
+        //offset should be either 4 or 5, depends on whether its daylight savings.
+        assert hrsOffset in [-4,-5]
+        ChronoUnit.HOURS.between(ldNow, ldEt) == hrsOffset
+        //ldEt.toString() == ldNow.toString()
+    }
+
+    def "test nowAppZone"() {
+        expect:
+        //truncate to minutes as they will be slightly off
+        //NOTE: its possible
+        LocalDate.nowAppZone() == LocalDate.now(ZoneId.appDefault())
+        checkSameDate(LocalDateTime.nowAppZone(), LocalDateTime.now(ZoneId.appDefault()))
+        checkSameDate(ZonedDateTime.nowAppZone(), ZonedDateTime.now(ZoneId.appDefault()))
+    }
+
+    def "test nowAppZone"() {
+        expect:
+        LocalDate.nowAppZone() == LocalDate.now(ZoneId.appDefault())
+
+    }
+
+    boolean checkSameDate(LocalDateTime t1, LocalDateTime t2){
+        return t1.truncatedTo(ChronoUnit.MINUTES) == t2.truncatedTo(ChronoUnit.MINUTES)
+    }
+
+    boolean checkSameDate(ZonedDateTime t1, ZonedDateTime t2){
+        return t1.truncatedTo(ChronoUnit.MINUTES) == t2.truncatedTo(ChronoUnit.MINUTES)
+    }
+}

--- a/groovy-commons/src/test/groovy/yakworks/commons/lang/ZonedDateUtilSpec.groovy
+++ b/groovy-commons/src/test/groovy/yakworks/commons/lang/ZonedDateUtilSpec.groovy
@@ -1,0 +1,134 @@
+/*
+* Copyright 2019 Yak.Works - Licensed under the Apache License, Version 2.0 (the "License")
+* You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+*/
+package yakworks.commons.lang
+
+import java.text.SimpleDateFormat
+import java.time.LocalDateTime
+import java.time.ZoneId
+import java.time.ZonedDateTime
+import java.time.temporal.ChronoUnit
+
+import org.springframework.util.StringUtils
+
+import spock.lang.Specification
+
+class ZonedDateUtilSpec extends Specification {
+
+    void "toLocalDateTimeZone"() {
+        when:
+        TimeZone.setDefault(TimeZone.getTimeZone("UTC"))
+        ZonedDateTime zdtUTCNow = ZonedDateTime.now()
+        var eastZone = ZoneId.of("America/New_York")
+        LocalDateTime ldEt = ZonedDateUtil.toLocalDateTimeZone(zdtUTCNow, eastZone)
+
+        int hrsOffset = ZonedDateUtil.hoursOffset(eastZone)
+
+        then:
+        //offset should be either 4 or 5, depends on whether its daylight savings.
+        assert hrsOffset in [-4,-5]
+        ZonedDateUtil.hoursBetween(zdtUTCNow.toLocalDateTime(), ldEt) == hrsOffset
+        //ldEt.toString() == ldNow.toString()
+    }
+
+    void "toZonedDateTime"() {
+        when:
+        TimeZone.setDefault(TimeZone.getTimeZone("UTC"))
+        ZonedDateTime zdtUTCNow = ZonedDateTime.now()
+        var eastZone = ZoneId.of("America/New_York")
+        ZonedDateTime zdEt = ZonedDateUtil.toZonedDateTime(zdtUTCNow, eastZone)
+
+        int hrsOffset = ZonedDateUtil.hoursOffset(eastZone)
+
+        then:
+        //offset should be either 4 or 5, depends on whether its daylight savings.
+        assert hrsOffset in [-4,-5]
+        ChronoUnit.HOURS.between(zdtUTCNow.toLocalDateTime(), zdEt.toLocalDateTime()) == hrsOffset
+        //ldEt.toString() == ldNow.toString()
+    }
+
+    void "isSameMinute isSameSecond"() {
+        when:
+        TimeZone.setDefault(TimeZone.getTimeZone("UTC"))
+        ZonedDateTime zdtUTCNow = ZonedDateTime.now()
+        var eastZone = ZoneId.of("America/New_York")
+        ZonedDateTime zdEt = ZonedDateUtil.toZonedDateTime(zdtUTCNow, eastZone)
+
+        then:
+        ChronoUnit.MINUTES.between(zdtUTCNow, zdEt) == 0
+        //ChronoUnit.MINUTES.between(zdtUTCNow.toLocalDateTime(), zdEt.toLocalDateTime()) == 0
+        ZonedDateUtil.isSameMinute(zdtUTCNow, zdEt)
+        ZonedDateUtil.isSameSecond(zdtUTCNow, zdEt)
+
+    }
+
+    void "isSameMinute isSameSecond same"() {
+        when:
+        ZonedDateTime zdtTime1 = ZonedDateTime.now(ZoneId.of("America/New_York"))
+        ZonedDateTime zdtTime2 = ZonedDateTime.now(ZoneId.of("America/New_York")) // ZonedDateUtil.toZonedDateTime(zdtTime1, eastZone)
+
+        then:
+        ZonedDateUtil.isSameMinute(zdtTime1, zdtTime2)
+        ZonedDateUtil.isSameSecond(zdtTime1, zdtTime2)
+        //but wont be equal as milliseconds are off
+        zdtTime1 != zdtTime2
+        //unlikely this will fail but its possible if zdtTime2 is the next minute.
+        zdtTime1.truncatedTo(ChronoUnit.MINUTES) == zdtTime2.truncatedTo(ChronoUnit.MINUTES)
+    }
+
+    void "test timezone playground"() {
+        setup:
+        //var tz = TimeZone.getDefault()
+        var tz1 = StringUtils.parseTimeZoneString("CST")
+        var utc = StringUtils.parseTimeZoneString("UTC")
+
+        expect:
+        StringUtils.parseTimeZoneString("CST").toZoneId().toString() == "America/Chicago"
+        StringUtils.parseTimeZoneString("PST").toZoneId().toString() == "America/Los_Angeles"
+        // StringUtils.parseTimeZoneString("MST").toZoneId().toString() == "America/Denver"
+        // StringUtils.parseTimeZoneString("EST").toZoneId().toString() == "America/New_York"
+        utc.toZoneId() == ZoneId.of("UTC")
+        //tz.toZoneId() == ZoneId.of("America/Denver")
+        tz1.toZoneId().toString() == "America/Chicago"
+        LocalDateTime localDateTime = LocalDateTime.parse("2023-09-20T13:59:59")
+        localDateTime.toString() == "2023-09-20T13:59:59"
+        ZonedDateTime zonedDateTime = localDateTime.atZone(ZoneId.of("America/Chicago"))
+        zonedDateTime.toString() == "2023-09-20T13:59:59-05:00[America/Chicago]"
+        //central time
+        var zonedDateTime2 = LocalDateTime.parse("2023-11-06T13:59:59").atZone(ZoneId.of("America/Chicago"))
+        zonedDateTime2.toString() == "2023-11-06T13:59:59-06:00[America/Chicago]"
+        zonedDateTime2.withZoneSameInstant(ZoneId.of("UTC")).toString() == "2023-11-06T19:59:59Z[UTC]"
+        zonedDateTime2.withZoneSameInstant(ZoneId.of("UTC")).toLocalDateTime().toString() == "2023-11-06T19:59:59"
+    }
+
+    void "local date zone conversion playground"() {
+        setup:
+        TimeZone.setDefault(TimeZone.getTimeZone("UTC"));
+
+        expect:
+        ZoneId.of("America/New_York").toString() == "America/New_York"
+        var ldt = LocalDateTime.parse("2023-09-20T01:01:01")
+        ldt.toString() == "2023-09-20T01:01:01"
+        ldt.toDate().toString() == "Wed Sep 20 01:01:01 UTC 2023"
+        // LocalDateTime.ofInstant(ldt.toInstant(ZoneOffset.of()))
+        var utc_ldt = ldt.atZone(ZoneId.of("UTC"))
+        utc_ldt.toString() == "2023-09-20T01:01:01Z[UTC]"
+        ZonedDateTime et_ldt = utc_ldt.withZoneSameInstant(ZoneId.of("America/New_York"))
+        et_ldt.toString() == "2023-09-19T21:01:01-04:00[America/New_York]"
+        et_ldt.toLocalDateTime().toString() == "2023-09-19T21:01:01"
+        new SimpleDateFormat("yyMMdd").format(et_ldt.toLocalDateTime().toDate()) == "230919"
+        et_ldt.toLocalDateTime().toDate().toString() == "Tue Sep 19 21:01:01 UTC 2023"
+        //without changing to LocalDateTime first it keeps timezone and adjusts it
+        et_ldt.toDate().toString() == "Wed Sep 20 01:01:01 UTC 2023"
+
+        var ldNow = LocalDateTime.now().truncatedTo(ChronoUnit.MINUTES)
+        var ldEt = LocalDateTime.now(ZoneId.of("America/New_York")).truncatedTo(ChronoUnit.MINUTES)
+
+        //need to handle daylight savings to get time diff between utc and nyc
+        ZonedDateTime nyc_time = ZonedDateTime.now( ZoneId.of( "America/New_York" ) )
+        int nyc_time_diff =  nyc_time.zone.rules.isDaylightSavings(nyc_time.toInstant()) ? 4 : 5
+        ChronoUnit.HOURS.between(ldEt, ldNow) == nyc_time_diff
+    }
+
+}


### PR DESCRIPTION
…meZone different than the system timezone that would normally be Zulu on server. (#26)

Can set to New York for example to so default LocalDate.nowAppZone() would give right date at 11:pm instead of tomorrow with Zulu.